### PR TITLE
Issue #1 - Do more checks

### DIFF
--- a/posconvert.module
+++ b/posconvert.module
@@ -69,6 +69,38 @@ function posconvert_preprocess_posconvert_form(&$variables, $hook) {
   $sample_Lc08 = $posconvert_path . '/includes/sample_lc08_positions.inc';
 
   $variables['posconvert_sample_file'] = $sample_Lc08;
+
+  // Max file limit.
+  $variables['posconvert_max_file_limit'] = ini_get('upload_max_filesize');
+  // Max line linmit.
+  $variables['posconvert_max_line_limit'] = 20000;
+
+  // Test to see if user has an ongoing download request.
+  // If so, prevent this form from loading and start a new convert process.
+  $log_user = $GLOBALS['user']->uid;
+  $module_name = 'trpdownload_api';
+  // Job status not listed below is considered an ongoing job.
+  $job_name = 'Download Posconvert TSV';
+  $job_status = array('Completed', 'Error', 'Cancelled');
+
+  $sql = "SELECT job_id FROM tripal_jobs
+    WHERE
+      uid = :log_user
+      AND modulename = :module_name
+      AND job_name = :job_name
+      AND TRIM(status) NOT IN (:job_status)
+    LIMIT 1";
+
+  $args = array(
+    ':log_user'    => $log_user,
+    ':module_name' => $module_name,
+    ':job_name'    => $job_name,
+    ':job_status'  => $job_status
+  );
+
+  $job = db_query($sql, $args);
+
+  $variables['posconvert_has_job'] = ($job->rowCount()) ? 1 : 0;
 }
 
 
@@ -236,7 +268,12 @@ function posconvert_form($form, &$form_state) {
         $lines = $file_row_count;
       }
 
-      if ($cols < 2 || count($check_rows) <= 0) {
+      if ($lines > 19500) {
+        // Too many lines nearing the allowed line limit.
+        $form['ajax_wrapper']['error']['#markup'] =
+          '<div class="messages error">Text data is near the limit of allowed number of line. Please try again.</div>';
+      }
+      elseif ($cols < 2 || count($check_rows) <= 0) {
         // Not enough columns.
         $form['ajax_wrapper']['error']['#markup'] =
           '<div class="messages error">Text data does not contain enough columns/rows or is not tab separated. Please try again.</div>';
@@ -655,6 +692,23 @@ function posconvert_register_trpdownload_type() {
   );
 
   return $types;
+}
+
+/**
+ * Display additional instruction to user while in download page.
+ */
+function posconvert_trpdownload_summarize_download($vars) {
+  $notice = '
+    <div style="position: absolute; margin: 130px auto 0 auto; display: inline-block; left: 1%; width: 98%; text-align: left;">
+      <div class="messages status warning" style="font-size: 1.2em">
+        Please do not navigate away from this page if you wish to download your converted file.
+        Once the progress bar has started, your file is already submitted to the system and
+        it will need to complete before any other files can start converting (<em>this also includes other users</em>).
+        Thank you for your patience!
+      </div>
+    </div>';
+
+  return $notice;
 }
 
 /**

--- a/posconvert.module
+++ b/posconvert.module
@@ -71,9 +71,9 @@ function posconvert_preprocess_posconvert_form(&$variables, $hook) {
   $variables['posconvert_sample_file'] = $sample_Lc08;
 
   // Max file limit.
-  $variables['posconvert_max_file_limit'] = ini_get('upload_max_filesize');
+  $variables['posconvert_max_file_limit'] = posconvert_max_line_limit('file_size');
   // Max line linmit.
-  $variables['posconvert_max_line_limit'] = 20000;
+  $variables['posconvert_max_line_limit'] = posconvert_max_line_limit('line_limit');
 
   // Test to see if user has an ongoing download request.
   // If so, prevent this form from loading and start a new convert process.
@@ -260,7 +260,7 @@ function posconvert_form($form, &$form_state) {
     }
     else {
       // Next test, see if it has sufficient columns.
-      list($cols, $lines, $check_rows) = posconvert_read_textdata($txt_data, 'get_cols');
+      list($cols, $lines, $check_rows, $ignore_rows) = posconvert_read_textdata($txt_data, 'get_cols');
 
       // Since only section of the file is retured, ensure the tripal download api
       // uses the right number of lines/rows.
@@ -268,7 +268,9 @@ function posconvert_form($form, &$form_state) {
         $lines = $file_row_count;
       }
 
-      if ($lines > 19500) {
+
+      $max_line_limit = posconvert_max_line_limit('line_limit');
+      if (($lines - $ignore_rows) > $max_line_limit) {
         // Too many lines nearing the allowed line limit.
         $form['ajax_wrapper']['error']['#markup'] =
           '<div class="messages error">Your file exceeds the maximum number of lines. Please try a smaller file or contact us.</div>';
@@ -594,15 +596,18 @@ function posconvert_read_textdata($data, $flag) {
     $columns = str_getcsv($first_line, "\t");
     $total_cols = count($columns);
 
+    $total_rows_ignore = count($rows_ignore);
+
     // 1. Return the total number of columns present.
     //    Use the value to let user select backbone and position columns.
     // 2. Return total number of lines used in updating progress bar.
     // 3. First x rows.
     //    To validate if pos and backbone are valid and source of options for backbone and position
     //    select boxes in step 2.
+    // 4. Rows to ignore (#) - To be used to get the actual count of lines to convert.
 
     // in the order above.
-    return array($total_cols, $total_rows, $rows_for_check);
+    return array($total_cols, $total_rows, $rows_for_check, $total_rows_ignore);
   }
   elseif ($flag == 'lim_rows') {
     // When large file is supplied, limit the large text data.
@@ -763,4 +768,40 @@ function posconvert_trpdownload_generate_file($variables, $job_id = NULL) {
 
   // Convert.
   posconvert_convert_SNPs_with_agp($input_file, $agp_file, $backbone, $position, $output_file, $job_id, $total_lines);
+}
+
+
+/**
+ * Helper function: Return max line and file size limit.
+ */
+function posconvert_max_line_limit($setting) {
+  switch($setting) {
+    case 'line_limit':
+      return 20000;
+      break;
+
+    case 'file_size':
+      // Setting has M.
+      $l = ini_get('upload_max_filesize');
+      $file_limit = trim(str_replace('M', '', $l));
+      return $file_limit;
+      break;
+  }
+}
+
+
+/**
+ * Implements hook_file_validate().
+ */
+function posconvert_file_validate($file) {
+  if ($file->source == 'file') {
+    $file_size = $file->filesize;
+    $file_limit = posconvert_max_line_limit('file_size');
+    $file_limit *= 1000000;
+
+    if ($file_size >= $file_limit) {
+      drupal_set_message('File uploaded exceeds the maximum file size limit. Please try a smaller file or contact us.', 'error');
+      return FALSE;
+    }
+  }
 }

--- a/posconvert.module
+++ b/posconvert.module
@@ -271,7 +271,7 @@ function posconvert_form($form, &$form_state) {
       if ($lines > 19500) {
         // Too many lines nearing the allowed line limit.
         $form['ajax_wrapper']['error']['#markup'] =
-          '<div class="messages error">Text data is near the limit of allowed number of line. Please try again.</div>';
+          '<div class="messages error">Your file exceeds the maximum number of lines. Please try a smaller file or contact us.</div>';
       }
       elseif ($cols < 2 || count($check_rows) <= 0) {
         // Not enough columns.

--- a/theme/css/style.posconvert.css
+++ b/theme/css/style.posconvert.css
@@ -274,7 +274,7 @@ span.win-loading {
   margin: 0;
 }
 
-#posconvert-form .messages ul li {
+#container-warning ul li {
   background: url('../img/message-16-ok.png') no-repeat left top;
   line-height: 17px;
   margin: 10px 0 10px 0;

--- a/theme/posconvert_page.tpl.php
+++ b/theme/posconvert_page.tpl.php
@@ -10,11 +10,11 @@
 ?>
 
 <div id="div-page-ctr-panel">
-  <div class="messages warning">
+  <div id="container-warning" class="messages warning">
     <p>
       <strong>This is a <em>Beta Release</em> and is still undergoing testing.</strong>
       <em style="color: red; font-weight: bold">Important:</em>
-      Posconvert is limited to files that are less than <?php print $posconvert_max_file_limit; ?>b or <?php print number_format($posconvert_max_line_limit); ?> lines (not including the header).
+      Posconvert is limited to files that are less than <?php print $posconvert_max_file_limit; ?>Mb or <?php print number_format($posconvert_max_line_limit); ?> lines (not including the header).
       It will take up to an hour to convert <?php print number_format($posconvert_max_line_limit); ?> lines. If you have a larger file, please
       contact us directly for help converting your file.
     </p>

--- a/theme/posconvert_page.tpl.php
+++ b/theme/posconvert_page.tpl.php
@@ -15,7 +15,7 @@
       <strong>This is a <em>Beta Release</em> and is still undergoing testing.</strong>
       <em style="color: red; font-weight: bold">Important:</em>
       Posconvert is limited to files that are less than <?php print $posconvert_max_file_limit; ?>b or <?php print number_format($posconvert_max_line_limit); ?> lines (not including the header).
-      It will take up to an hour to conver a file  of <?php print number_format($posconvert_max_line_limit); ?> lines. If you have a larger file, please
+      It will take up to an hour to convert <?php print number_format($posconvert_max_line_limit); ?> lines. If you have a larger file, please
       contact us directly for help converting your file.
     </p>
 
@@ -45,7 +45,7 @@
 if ($posconvert_has_job) {
 ?>
 
-  <div class="messages status warning">We have detected that you have an ongoing Position Convert request. Please allow thie request to complete before doing another conversion.</div>
+  <div class="messages status warning">We have detected that you have an ongoing Position Convert request. Please allow the request to complete before doing another conversion.</div>
 
 <?php
 }

--- a/theme/posconvert_page.tpl.php
+++ b/theme/posconvert_page.tpl.php
@@ -11,7 +11,14 @@
 
 <div id="div-page-ctr-panel">
   <div class="messages warning">
-    <strong>This is a <em>Beta Release</em> and is still undergoing testing.</strong>
+    <p>
+      <strong>This is a <em>Beta Release</em> and is still undergoing testing.</strong>
+      <em style="color: red; font-weight: bold">Important:</em>
+      Posconvert is limited to files that are less than <?php print $posconvert_max_file_limit; ?>b or <?php print number_format($posconvert_max_line_limit); ?> lines (not including the header).
+      It will take up to an hour to conver a file  of <?php print number_format($posconvert_max_line_limit); ?> lines. If you have a larger file, please
+      contact us directly for help converting your file.
+    </p>
+
     Double check that you have:
     <ul>
       <li>Chosen the correct columns for the name of the backbone (ie. contig) and position on the genome.</li>
@@ -35,6 +42,17 @@
 </div>
 
 <?php
+if ($posconvert_has_job) {
+?>
+
+  <div class="messages status warning">We have detected that you have an ongoing Position Convert request. Please allow thie request to complete before doing another conversion.</div>
+
+<?php
+}
+else {
+
   // Render form elements.
   print drupal_render_children($form);
+
+}
 ?>


### PR DESCRIPTION
- Amended the notice/warning area to include about file size and data
rows limit.

- Added a check to see if user has an ongoing posconvert job request.
This is done by checking the tripal job table for jobs created by user, by the module
and if the status is not completed, error or cancelled.

Please review the warning message top of the posconvert form.

To test Prevent user from running another job.
1. Posconvert a text data. When a tripal job has been registered, load the main posconvert form.
  It should display a message about ongoin posconvert job registered.
2. Once download is complete, reload the same page.
  It should load the form ready for the next posconvert.

To test 20000 line.
1. Please upload or if possible, paste text data into the text area.
   It should warn user about excessive rows.

Thanks!
